### PR TITLE
Fix visibility of CifarResult members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cifar-ten"
-version = "0.5.0"
+version = "0.5.1"
 authors = [
     "Christopher Moran <christopher.and.moran@gmail.com>",
     "Manuel Drehwald"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ use std::fs::File;
 use tar::Archive;
 
 /// Primary data return, wrapper around tuple `(Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>)`
-pub struct CifarResult(Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>);
+pub struct CifarResult(pub Vec<u8>, pub Vec<u8>, pub Vec<u8>, pub Vec<u8>);
 
 /// Data structure used to specify where/how the CIFAR-10 binary data is parsed
 #[derive(Debug)]


### PR DESCRIPTION
If one wishes to not use the `to_ndarray` feature, the CifarResult cannot be used from an external API because the members of the Enum are private. Make them pubic so the type can be used in an external library.