### PR TITLE
update cifar-ten for ndarray 0.16 and get tests running on macos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,5 +44,5 @@ tar = {version = "0.4", optional = true}
 
 [dev-dependencies]
 # Used to show datasets
-image = "0.23"
-show-image = {version = "0.6", features = ["image"]}
+image = "0.25"
+show-image = {version = "=0.14.0", features = ["image"]}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Convenience methods for converting these to the Rust `ndarray` numeric arrays ar
 well as for automatically downloading binary training data from a remote url. 
 
 ```rust
-// $ cargo build --features=download,to_ndarray_015
+// $ cargo build --features=download,to_ndarray_016
 use cifar_ten::*;
 
 fn main() {

--- a/examples/preview_images.rs
+++ b/examples/preview_images.rs
@@ -5,8 +5,11 @@ use ndarray_013 as ndarray;
 use ndarray_014 as ndarray;
 #[cfg(feature = "to_ndarray_015")]
 use ndarray_015 as ndarray;
+#[cfg(feature = "to_ndarray_016")]
+use ndarray_016 as ndarray;
 
 #[cfg(any(
+    feature = "to_ndarray_016",
     feature = "to_ndarray_015",
     feature = "to_ndarray_014",
     feature = "to_ndarray_013"
@@ -14,9 +17,15 @@ use ndarray_015 as ndarray;
 use ndarray::prelude::*;
 
 use image::*;
-use show_image::{make_window_full, Event, WindowOptions};
+use show_image::{
+    create_window,
+    event::{WindowEvent, WindowKeyboardInputEvent},
+    glam::UVec2,
+    BoxImage, ImageInfo, WindowOptions,
+};
 use std::error::Error;
 
+#[show_image::main]
 fn main() {
     let (train_data, train_labels, test_data, test_labels) = Cifar10::default()
         .download_and_extract(true)
@@ -47,25 +56,32 @@ fn main() {
 pub fn display_img(img_arr: &Array3<u8>) -> Result<(), Box<dyn Error>> {
     let test_result_img = convert_to_image(img_arr);
 
+    // let boxed_image = BoxImage::new(
+    //     ImageInfo {
+    //         pixel_format: show_image::PixelFormat::Rgb8,
+    //         size: UVec2::new(32, 32),
+    //         strides: UVec2::new(3, 3 * 32),
+    //     },
+    //     img_arr,
+    // );
+
     let window_options = WindowOptions {
-        name: "image".to_string(),
-        size: [100, 100],
         resizable: true,
         preserve_aspect_ratio: true,
+        ..WindowOptions::default()
     };
     println!("\nPlease hit [ ESC ] to quit window:");
-    let window = make_window_full(window_options)?;
-    window.set_image(test_result_img, "test_result").unwrap();
+    let window = create_window("cifar-10", Default::default())?;
+    window.set_image("test_result", test_result_img).unwrap();
 
-    for event in window.events() {
-        if let Event::KeyboardEvent(event) = event {
-            if event.key == show_image::KeyCode::Escape {
+    for event in window.event_channel()? {
+        if let WindowEvent::KeyboardInput(WindowKeyboardInputEvent { input, .. }) = event {
+            if input.key_code == Some(show_image::event::VirtualKeyCode::Escape) {
                 break;
             }
         }
     }
 
-    show_image::stop()?;
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! well as for automatically downloading binary training data from a remote url.  
 //!
 //! ```rust
-//! // $ cargo build --features=download,to_ndarray
+//! // $ cargo build --features=download,to_ndarray_016
 //! use cifar_ten::*;
 //!
 //! fn main() {
@@ -31,6 +31,7 @@
 mod test;
 
 #[cfg(any(
+    feature = "to_ndarray_016",
     feature = "to_ndarray_015",
     feature = "to_ndarray_014",
     feature = "to_ndarray_013"
@@ -43,6 +44,8 @@ use ndarray_013 as ndarray;
 use ndarray_014 as ndarray;
 #[cfg(feature = "to_ndarray_015")]
 use ndarray_015 as ndarray;
+#[cfg(feature = "to_ndarray_016")]
+use ndarray_016 as ndarray;
 
 use std::error::Error;
 use std::io::Read;
@@ -236,6 +239,7 @@ fn get_data(config: &Cifar10, dataset: &str) -> Result<(Vec<u8>, Vec<u8>), Box<d
 
 impl CifarResult {
     #[cfg(any(
+        feature = "to_ndarray_016",
         feature = "to_ndarray_015",
         feature = "to_ndarray_014",
         feature = "to_ndarray_013"
@@ -257,6 +261,7 @@ impl CifarResult {
 }
 
 #[cfg(any(
+    feature = "to_ndarray_016",
     feature = "to_ndarray_015",
     feature = "to_ndarray_014",
     feature = "to_ndarray_013"


### PR DESCRIPTION
Fixes #11.

I also updated show-image and modified the code so it now can run the example on MacOS so that I could test it.